### PR TITLE
Fixed webshell image building failure in CI

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - "master"
 
+env:
+  K8S_VERSION: v1.23.6 # the same as Makefile
+  HELM_VERSION: v3.7.1 # the same as Makefile
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -35,6 +39,9 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            K8S_VERSION=${{ env.K8S_VERSION }}
+            HELM_VERSION=${{ env.HELM_VERSION }}
           push: true
           tags: |
             ${{ secrets.DOCKER_NAME }}/pixiu-webshell:latest


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixed webshell image building failure in CI:

```txt
------
 > [linux/amd64 5/7] RUN ARCH=$(uname -m|sed 's|x86_64|amd64|'|sed 's|aarch64|arm64|') &&     curl -LO "[https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz](https://get.helm.sh/helm-$%7BHELM_VERSION%7D-linux-$%7BARCH%7D.tar.gz)" &&     tar -zxvf helm-${HELM_VERSION}-linux-${ARCH}.tar.gz &&     rm -rf helm-${HELM_VERSION}-linux-${ARCH}.tar.gz &&     mv linux-${ARCH}/helm /usr/local/bin/helm &&     rm -rf linux-${ARCH}:
    0 --:--:-- --:--:-- --:--:--   571
0.458 
0.458 gzip: stdin: not in gzip format
0.459 tar: Child returned status 1
0.459 tar: Error is not recoverable: exiting now
------
Dockerfile:20
--------------------
  19 |     # 安装 helm
  20 | >>> RUN ARCH=$(uname -m|sed 's|x86_64|amd64|'|sed 's|aarch64|arm64|') && \
  21 | >>>     curl -LO "[https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz](https://get.helm.sh/helm-$%7BHELM_VERSION%7D-linux-$%7BARCH%7D.tar.gz)" && \
  22 | >>>     tar -zxvf helm-${HELM_VERSION}-linux-${ARCH}.tar.gz && \
  23 | >>>     rm -rf helm-${HELM_VERSION}-linux-${ARCH}.tar.gz && \
  24 | >>>     mv linux-${ARCH}/helm /usr/local/bin/helm && \
  25 | >>>     rm -rf linux-${ARCH}
  26 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c ARCH=$(uname -m|sed 's|x86_64|amd64|'|sed 's|aarch64|arm64|') &&     curl -LO \"[https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz\](https://get.helm.sh/helm-$%7BHELM_VERSION%7D-linux-$%7BARCH%7D.tar.gz/)" &&     tar -zxvf helm-${HELM_VERSION}-linux-${ARCH}.tar.gz &&     rm -rf helm-${HELM_VERSION}-linux-${ARCH}.tar.gz &&     mv linux-${ARCH}/helm /usr/local/bin/helm &&     rm -rf linux-${ARCH}" did not complete successfully: exit code: 2
Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c ARCH=$(uname -m|sed 's|x86_64|amd64|'|sed 's|aarch64|arm64|') &&     curl -LO \"[https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz\](https://get.helm.sh/helm-$%7BHELM_VERSION%7D-linux-$%7BARCH%7D.tar.gz/)" &&     tar -zxvf helm-${HELM_VERSION}-linux-${ARCH}.tar.gz &&     rm -rf helm-${HELM_VERSION}-linux-${ARCH}.tar.gz &&     mv linux-${ARCH}/helm /usr/local/bin/helm &&     rm -rf linux-${ARCH}" did not complete successfully: exit code: 2
```

#### Which issue(s) this PR fixes:
Fixes #354 build <https://github.com/caoyingjunz/pixiu/actions/runs/7684599310/job/20941284754>

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
