### PR TITLE
Add version sub command to server app

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,7 +16,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Get short commit hash
-        run: echo "COMMIT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: |
+          echo "COMMIT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "TIMESTAMP=$(date +%Y%m%d%H%M%S)" >> $GITHUB_ENV
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -36,6 +38,8 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ env.COMMIT_HASH }}-${{ env.TIMESTAMP }}
           push: true
           tags: |
             ${{ secrets.DOCKER_NAME }}/pixiu:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM golang:1.17-alpine as builder
 WORKDIR /app
+ARG VERSION
 ENV GOPROXY=https://goproxy.cn
 COPY ./go.mod ./
 COPY ./go.sum ./
 #RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -ldflags "-s -w" -o pixiu ./cmd
+RUN CGO_ENABLED=0 go build -ldflags "-s -w -X 'main.version=${VERSION}'" -o pixiu ./cmd
 
 FROM busybox as runner
 COPY --from=builder /app/pixiu /app

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,13 @@
 
 tag = v0.1
 releaseName = pixiu
-dockerhubUser = jacky06
+dockerhubUser ?= jacky06
 k8sVersion ?= v1.23.6
 helmVersion ?= v3.7.1
+targetDir ?= dist
+commitHash = $(shell git rev-parse --short HEAD)
+# e.g. 1862ce5-20240203180617
+version = $(commitHash)-$(shell date +%Y%m%d%H%M%S)
 
 ALL: run
 
@@ -12,10 +16,10 @@ run: build
 	./pixiu --configfile ./config.yaml
 
 build:
-	go build -o $(releaseName) ./cmd/
+	go build -o $(targetDir)/$(releaseName) -ldflags "-X 'main.version=$(version)'" ./cmd/
 
 image:
-	docker build -t $(dockerhubUser)/$(releaseName):$(tag) .
+	docker build -t $(dockerhubUser)/$(releaseName):$(tag) --build-arg VERSION=$(version) .
 
 push: image
 	docker push $(dockerhubUser)/$(releaseName):$(tag)

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -32,7 +32,7 @@ import (
 	"github.com/caoyingjunz/pixiu/cmd/app/options"
 )
 
-func NewServerCommand() *cobra.Command {
+func NewServerCommand(version string) *cobra.Command {
 	opts, err := options.NewOptions()
 	if err != nil {
 		klog.Fatalf("unable to initialize command options: %v", err)
@@ -67,6 +67,16 @@ func NewServerCommand() *cobra.Command {
 
 	// 绑定命令行参数
 	opts.BindFlags(cmd)
+
+	verCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print the version",
+		Long:  "Print version and exit.",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(version)
+		},
+	}
+	cmd.AddCommand(verCmd)
 	return cmd
 }
 

--- a/cmd/pixiuserver.go
+++ b/cmd/pixiuserver.go
@@ -28,6 +28,8 @@ import (
 	"github.com/caoyingjunz/pixiu/cmd/app"
 )
 
+var version string
+
 // @title           Pixiu API Documentation
 // @version         1.0
 // @termsOfService  https://github.com/caoyingjunz/pixiu
@@ -53,7 +55,7 @@ func main() {
 	gin.SetMode(gin.ReleaseMode)
 	gin.DefaultWriter = io.Discard
 
-	cmd := app.NewServerCommand()
+	cmd := app.NewServerCommand(version)
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Printing build version is very helpful sometimes.
The version string is composed of short commit hash and timestamp of building:
e.g. `e2d0229-20240203182320`

#### Does this PR introduce a user-facing change?

Add a `version` sub command  to pixiu server app:

```bash
$ make build
go build -o dist/pixiu -ldflags "-X 'main.version=e2d0229-20240203182320'" ./cmd/
$ ./dist/pixiu version
e2d0229-20240203182320
```
