### PR TITLE
Skip 2 more special URL paths

### DIFF
--- a/api/server/middleware/authorization.go
+++ b/api/server/middleware/authorization.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/caoyingjunz/pixiu/api/server/httputils"
+	"github.com/caoyingjunz/pixiu/api/server/router/cluster"
 	"github.com/caoyingjunz/pixiu/api/server/router/proxy"
 	"github.com/caoyingjunz/pixiu/cmd/app/options"
 	"github.com/caoyingjunz/pixiu/pkg/db/model"
@@ -66,7 +67,7 @@ func Authorization(o *options.Options) gin.HandlerFunc {
 
 		// Proxy path should be skipped now.
 		// TODO: get object and ID from proxy path
-		if proxy.IsProxyPath(c) {
+		if proxy.IsProxyPath(c) || cluster.IsKubeProxyPath(c) || cluster.IsHelmPath(c) {
 			return
 		}
 

--- a/api/server/router/cluster/cluster.go
+++ b/api/server/router/cluster/cluster.go
@@ -23,6 +23,11 @@ import (
 	"github.com/caoyingjunz/pixiu/pkg/controller"
 )
 
+const (
+	kubeProxyBaseURL = "/pixiu/kubeproxy"
+	helmBaseURL      = "/pixiu/helms"
+)
+
 // clusterRouter is a router to talk with the cluster controller
 type clusterRouter struct {
 	c controller.PixiuInterface
@@ -53,7 +58,7 @@ func (cr *clusterRouter) initRoutes(httpEngine *gin.Engine) {
 	}
 
 	// 调用 kubernetes 对象
-	kubeRoute := httpEngine.Group("/pixiu/kubeproxy")
+	kubeRoute := httpEngine.Group(kubeProxyBaseURL)
 	{
 		// Deprecated 聚合 events
 		kubeRoute.GET("/clusters/:cluster/namespaces/:namespace/name/:name/kind/:kind/events", cr.aggregateEvents)
@@ -65,7 +70,7 @@ func (cr *clusterRouter) initRoutes(httpEngine *gin.Engine) {
 	}
 
 	// 调用 helm 对象
-	helmRoute := httpEngine.Group("/pixiu/helms")
+	helmRoute := httpEngine.Group(helmBaseURL)
 	{
 		// 获取 release 列表
 		helmRoute.GET("/clusters/:cluster/v1/namespaces/:namespace/releases", cr.ListReleases)

--- a/api/server/router/cluster/helper.go
+++ b/api/server/router/cluster/helper.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2024 The Pixiu Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+func IsKubeProxyPath(c *gin.Context) bool {
+	return strings.HasPrefix(c.Request.URL.Path, kubeProxyBaseURL)
+}
+
+func IsHelmPath(c *gin.Context) bool {
+	return strings.HasPrefix(c.Request.URL.Path, helmBaseURL)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`/pixiu/kubeproxy` and `/pixiu/helms` should be skipped now in authorization middleware.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
