### PR TITLE
Add a RBAC policy create API

### DIFF
--- a/api/server/middleware/audit.go
+++ b/api/server/middleware/audit.go
@@ -88,12 +88,12 @@ func (w *auditWriter) asyncAudit(c *gin.Context) {
 	}
 
 	audit := &model.Audit{
-		Action:       c.Request.Method,
-		Ip:           c.ClientIP(),
-		Operator:     userName,
-		Path:         c.Request.RequestURI,
-		ResourceType: obj,
-		Status:       status,
+		Action:     c.Request.Method,
+		Ip:         c.ClientIP(),
+		Operator:   userName,
+		Path:       c.Request.RequestURI,
+		ObjectType: model.ObjectType(obj),
+		Status:     status,
 	}
 	if _, err := w.opts.Factory.Audit().Create(context.TODO(), audit); err != nil {
 		klog.Errorf("failed to create audit record [%s]: %v", audit.String(), err)

--- a/api/server/router/auth/auth.go
+++ b/api/server/router/auth/auth.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2024 The Pixiu Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/caoyingjunz/pixiu/cmd/app/options"
+	"github.com/caoyingjunz/pixiu/pkg/controller"
+)
+
+type authRouter struct {
+	c controller.PixiuInterface
+}
+
+func NewRouter(o *options.Options) {
+	router := &authRouter{
+		c: o.Controller,
+	}
+	router.initRoutes(o.HttpEngine)
+}
+
+func (a *authRouter) initRoutes(ge *gin.Engine) {
+	authRoute := ge.Group("/pixiu/auth")
+	{
+		policyRoute := authRoute.Group("/policy")
+		policyRoute.POST("", a.createPolicy)
+	}
+}

--- a/api/server/router/auth/auth_routes.go
+++ b/api/server/router/auth/auth_routes.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2024 The Pixiu Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/caoyingjunz/pixiu/api/server/httputils"
+	"github.com/caoyingjunz/pixiu/pkg/types"
+)
+
+func (a *authRouter) createPolicy(c *gin.Context) {
+	r := httputils.NewResponse()
+	var req types.CreateRBACPolicyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputils.SetFailed(c, r, err)
+		return
+	}
+	if err := a.c.Auth().CreateRBACPolicy(c, &req); err != nil {
+		httputils.SetFailed(c, r, err)
+		return
+	}
+
+	httputils.SetSuccess(c, r)
+}

--- a/api/server/router/router.go
+++ b/api/server/router/router.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/caoyingjunz/pixiu/api/server/middleware"
 	"github.com/caoyingjunz/pixiu/api/server/router/audit"
+	"github.com/caoyingjunz/pixiu/api/server/router/auth"
 	"github.com/caoyingjunz/pixiu/api/server/router/cluster"
 	"github.com/caoyingjunz/pixiu/api/server/router/plan"
 	"github.com/caoyingjunz/pixiu/api/server/router/proxy"
@@ -41,7 +42,14 @@ type RegisterFunc func(o *options.Options)
 
 func InstallRouters(o *options.Options) {
 	fs := []RegisterFunc{
-		middleware.InstallMiddlewares, cluster.NewRouter, proxy.NewRouter, tenant.NewRouter, user.NewRouter, plan.NewRouter, audit.NewRouter,
+		middleware.InstallMiddlewares,
+		cluster.NewRouter,
+		proxy.NewRouter,
+		tenant.NewRouter,
+		user.NewRouter,
+		plan.NewRouter,
+		audit.NewRouter,
+		auth.NewRouter,
 	}
 
 	install(o, fs...)

--- a/api/server/validator/rbac.go
+++ b/api/server/validator/rbac.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2024 The Pixiu Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validator
+
+import (
+	"strconv"
+
+	"github.com/caoyingjunz/pixiu/pkg/db/model"
+	"github.com/go-playground/validator/v10"
+)
+
+func init() {
+	register(
+		&objectValidator{pixiuValidator: newPixiuValidator("rbac_object", "对象类型不支持")},
+		&operationValidator{pixiuValidator: newPixiuValidator("rbac_operation", "操作不支持")},
+		&stringIDValidator{pixiuValidator: newPixiuValidator("rbac_sid", "不合法")},
+	)
+}
+
+type objectValidator struct {
+	pixiuValidator
+}
+
+func (ov *objectValidator) validate(fl validator.FieldLevel) bool {
+	obj := fl.Field().Interface().(model.ObjectType)
+	_, ok := model.ObjectTypeMap[obj]
+	return ok
+}
+
+type operationValidator struct {
+	pixiuValidator
+}
+
+func (ov *operationValidator) validate(fl validator.FieldLevel) bool {
+	op := fl.Field().Interface().(model.Operation)
+	_, ok := model.OperationMap[op]
+	return ok
+}
+
+type stringIDValidator struct {
+	pixiuValidator
+}
+
+func (sv *stringIDValidator) validate(fl validator.FieldLevel) bool {
+	sid := fl.Field().String()
+	if sid == "*" {
+		return true
+	}
+	_, err := strconv.Atoi(sid)
+	return err == nil
+}

--- a/pkg/controller/audit/audit.go
+++ b/pkg/controller/audit/audit.go
@@ -79,12 +79,12 @@ func (a *audit) model2Type(o *model.Audit) *types.Audit {
 			GmtCreate:   o.GmtCreate,
 			GmtModified: o.GmtModified,
 		},
-		Ip:           o.Ip,
-		Action:       o.Action,
-		Status:       o.Status,
-		Operator:     o.Operator,
-		Path:         o.Path,
-		ResourceType: o.ResourceType,
+		Ip:         o.Ip,
+		Action:     o.Action,
+		Status:     o.Status,
+		Operator:   o.Operator,
+		Path:       o.Path,
+		ObjectType: o.ObjectType,
 	}
 }
 

--- a/pkg/controller/auth/auth.go
+++ b/pkg/controller/auth/auth.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2024 The Pixiu Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+
+	"github.com/casbin/casbin/v2"
+	"k8s.io/klog/v2"
+
+	"github.com/caoyingjunz/pixiu/api/server/errors"
+	"github.com/caoyingjunz/pixiu/pkg/db"
+	"github.com/caoyingjunz/pixiu/pkg/db/model"
+	"github.com/caoyingjunz/pixiu/pkg/types"
+)
+
+type AuthGetter interface {
+	Auth() Interface
+}
+
+type Interface interface {
+	CreateRBACPolicy(ctx context.Context, req *types.CreateRBACPolicyRequest) error
+}
+
+type auth struct {
+	enforcer *casbin.SyncedEnforcer
+	factory  db.ShareDaoFactory
+}
+
+func NewAuth(factory db.ShareDaoFactory, enforcer *casbin.SyncedEnforcer) Interface {
+	return &auth{
+		factory:  factory,
+		enforcer: enforcer,
+	}
+}
+
+func (a *auth) CreateRBACPolicy(ctx context.Context, req *types.CreateRBACPolicyRequest) error {
+	user, err := a.factory.User().Get(ctx, req.UserId)
+	if err != nil {
+		klog.Errorf("failed to get user(%d): %v", req.UserId, err)
+		return errors.ErrServerInternal
+	}
+	if user == nil {
+		return errors.ErrUserNotFound
+	}
+
+	policy := model.MakePolicy(user.Name, req.ObjectType, req.SID, req.Operation)
+	if _, err := a.enforcer.AddPolicy(policy); err != nil {
+		klog.Errorf("failed to create policy %v: %v", policy, err)
+		return errors.ErrServerInternal
+	}
+	return nil
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/caoyingjunz/pixiu/cmd/app/config"
 	"github.com/caoyingjunz/pixiu/pkg/controller/audit"
+	"github.com/caoyingjunz/pixiu/pkg/controller/auth"
 	"github.com/caoyingjunz/pixiu/pkg/controller/cluster"
 	"github.com/caoyingjunz/pixiu/pkg/controller/plan"
 	"github.com/caoyingjunz/pixiu/pkg/controller/tenant"
@@ -34,6 +35,7 @@ type PixiuInterface interface {
 	user.UserGetter
 	plan.PlanGetter
 	audit.AuditGetter
+	auth.AuthGetter
 }
 
 type pixiu struct {
@@ -47,6 +49,7 @@ func (p *pixiu) Tenant() tenant.Interface   { return tenant.NewTenant(p.cc, p.fa
 func (p *pixiu) User() user.Interface       { return user.NewUser(p.cc, p.factory, p.enforcer) }
 func (p *pixiu) Plan() plan.Interface       { return plan.NewPlan(p.cc, p.factory) }
 func (p *pixiu) Audit() audit.Interface     { return audit.NewAudit(p.cc, p.factory) }
+func (p *pixiu) Auth() auth.Interface       { return auth.NewAuth(p.factory, p.enforcer) }
 
 func New(cfg config.Config, f db.ShareDaoFactory, enforcer *casbin.SyncedEnforcer) PixiuInterface {
 	return &pixiu{

--- a/pkg/db/model/audit.go
+++ b/pkg/db/model/audit.go
@@ -48,12 +48,12 @@ func (s AuditOperationStatus) String() string {
 type Audit struct {
 	pixiu.Model
 
-	Ip           string               `gorm:"type:varchar(128)" json:"ip"`            // 客户端ip
-	Action       string               `gorm:"type:varchar(255)" json:"action"`        // HTTP 方法[POST/DELETE/PUT/GET]
-	Operator     string               `gorm:"type:varchar(255)" json:"operator"`      // 操作人ID
-	Path         string               `gorm:"type:varchar(255)" json:"path"`          // HTTP 路径
-	ResourceType string               `gorm:"type:varchar(128)" json:"resource_type"` // 操作资源类型[cluster/plan...]
-	Status       AuditOperationStatus `gorm:"type:tinyint" json:"status"`             // 记录操作运行结果[OperationStatus]
+	Ip         string               `gorm:"type:varchar(128)" json:"ip"`                                 // 客户端ip
+	Action     string               `gorm:"type:varchar(255)" json:"action"`                             // HTTP 方法[POST/DELETE/PUT/GET]
+	Operator   string               `gorm:"type:varchar(255)" json:"operator"`                           // 操作人ID
+	Path       string               `gorm:"type:varchar(255)" json:"path"`                               // HTTP 路径
+	ObjectType ObjectType           `gorm:"column:resource_type;type:varchar(128)" json:"resource_type"` // 操作资源类型[cluster/plan...]
+	Status     AuditOperationStatus `gorm:"type:tinyint" json:"status"`                                  // 记录操作运行结果[OperationStatus]
 }
 
 func (a *Audit) String() string {

--- a/pkg/db/model/rbac.go
+++ b/pkg/db/model/rbac.go
@@ -23,10 +23,43 @@ const (
 	OpCreate Operation = "create"
 	OpUpdate Operation = "update"
 	OpDelete Operation = "delete"
+	OpAll    Operation = "*"
 )
 
 func (o Operation) String() string {
 	return string(o)
+}
+
+var OperationMap = map[Operation]struct{}{
+	OpRead:   {},
+	OpCreate: {},
+	OpUpdate: {},
+	OpDelete: {},
+	OpAll:    {},
+}
+
+type ObjectType string
+
+const (
+	ObjectUser    ObjectType = "users"
+	ObjectCluster ObjectType = "clusters"
+	ObjectTenant  ObjectType = "tenants"
+	ObjectPlan    ObjectType = "plans"
+	ObjectAuth    ObjectType = "auth"
+	ObjectAll     ObjectType = "*"
+)
+
+func (o ObjectType) String() string {
+	return string(o)
+}
+
+var ObjectTypeMap = map[ObjectType]struct{}{
+	ObjectUser:    {},
+	ObjectCluster: {},
+	ObjectTenant:  {},
+	ObjectPlan:    {},
+	ObjectAuth:    {},
+	ObjectAll:     {},
 }
 
 // TODO:
@@ -52,3 +85,9 @@ m = g(r.sub, p.sub) && keyMatch(r.obj, p.obj) && keyMatch(r.id, p.id) && keyMatc
 
 // TODO:
 type CasbinRBACImpl struct{}
+
+// MakePolicy returns a policy slice.
+// e.g. ["foo", "clusters", "*", "read"]
+func MakePolicy(username string, obj ObjectType, sid string, op Operation) []string {
+	return []string{username, obj.String(), sid, op.String()}
+}

--- a/pkg/types/request.go
+++ b/pkg/types/request.go
@@ -131,6 +131,14 @@ type (
 	}
 
 	UpdatePlanConfigRequest struct {
+		// TODO:
+	}
+
+	CreateRBACPolicyRequest struct {
+		UserId     int64            `json:"user_id" binding:"required"`
+		ObjectType model.ObjectType `json:"object_type" binding:"required,rbac_object"`
+		SID        string           `json:"sid" binding:"omitempty,rbac_sid"`
+		Operation  model.Operation  `json:"operation" binding:"required,rbac_operation"`
 	}
 )
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -133,12 +133,12 @@ type Audit struct {
 	PixiuMeta `json:",inline"`
 	TimeMeta  `json:",inline"`
 
-	Ip           string                     `json:"ip"`
-	Action       string                     `json:"action"`        // 操作动作
-	Status       model.AuditOperationStatus `json:"status"`        // 操作状态
-	Operator     string                     `json:"operator"`      // 操作人
-	Path         string                     `json:"path"`          // 操作路径
-	ResourceType string                     `json:"resource_type"` // 资源类型
+	Ip         string                     `json:"ip"`
+	Action     string                     `json:"action"`        // 操作动作
+	Status     model.AuditOperationStatus `json:"status"`        // 操作状态
+	Operator   string                     `json:"operator"`      // 操作人
+	Path       string                     `json:"path"`          // 操作路径
+	ObjectType model.ObjectType           `json:"resource_type"` // 资源类型
 }
 
 type AuthType string


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add a RBAC policy create API.

route: `/pixiu/auth/policy`
method: `POST`


#### Does this PR introduce a user-facing change?

Running `curl` like this:

```bash
$ curl -H 'Authorization: Bearer '${token}'' -X POST http://127.0.0.1:8090/pixiu/auth/policy \
    -d '{"user_id": 3, "object_type": "clusters", "sid": "*", "operation": "read"}'
```
