### PR TITLE
Fixed the issue of getting kubernetes resources out of order

### DIFF
--- a/pkg/controller/cluster/informer.go
+++ b/pkg/controller/cluster/informer.go
@@ -104,20 +104,14 @@ func (c *cluster) ListPods(ctx context.Context, podsLister v1.PodLister, namespa
 		return nil, err
 	}
 
-	sort.Slice(pods, func(i, j int) bool {
-		// sort by creation timestamp in descending order
-		if pods[j].ObjectMeta.GetCreationTimestamp().Time.Before(pods[i].ObjectMeta.GetCreationTimestamp().Time) {
-			return true
-		} else if pods[i].ObjectMeta.GetCreationTimestamp().Time.Before(pods[j].ObjectMeta.GetCreationTimestamp().Time) {
-			return false
-		}
-
-		// if the creation timestamps are equal, sort by name in ascending order
+	sort.SliceStable(pods, func(i, j int) bool {
 		return pods[i].ObjectMeta.GetName() < pods[j].ObjectMeta.GetName()
 	})
 	// 全量获取 pod 时，以命名空间排序
 	if len(namespace) == 0 {
-		sort.Slice(pods, func(i, j int) bool { return pods[i].ObjectMeta.GetNamespace() < pods[j].ObjectMeta.GetNamespace() })
+		sort.SliceStable(pods, func(i, j int) bool {
+			return pods[i].ObjectMeta.GetNamespace() < pods[j].ObjectMeta.GetNamespace()
+		})
 	}
 
 	return types.PageResponse{
@@ -147,19 +141,11 @@ func (c *cluster) ListDeployments(ctx context.Context, deploymentsLister listers
 		return nil, err
 	}
 
-	sort.Slice(deployments, func(i, j int) bool {
-		// sort by creation timestamp in descending order
-		if deployments[j].ObjectMeta.GetCreationTimestamp().Time.Before(deployments[i].ObjectMeta.GetCreationTimestamp().Time) {
-			return true
-		} else if deployments[i].ObjectMeta.GetCreationTimestamp().Time.Before(deployments[j].ObjectMeta.GetCreationTimestamp().Time) {
-			return false
-		}
-
-		// if the creation timestamps are equal, sort by name in ascending order
+	sort.SliceStable(deployments, func(i, j int) bool {
 		return deployments[i].ObjectMeta.GetName() < deployments[j].ObjectMeta.GetName()
 	})
 	if len(namespace) == 0 {
-		sort.Slice(deployments, func(i, j int) bool {
+		sort.SliceStable(deployments, func(i, j int) bool {
 			return deployments[i].ObjectMeta.GetNamespace() < deployments[j].ObjectMeta.GetNamespace()
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
