### PR TITLE
Add a RBAC policies listing API

### DIFF
--- a/api/server/router/auth/auth.go
+++ b/api/server/router/auth/auth.go
@@ -40,5 +40,6 @@ func (a *authRouter) initRoutes(ge *gin.Engine) {
 		policyRoute := authRoute.Group("/policy")
 		policyRoute.POST("", a.createPolicy)
 		policyRoute.DELETE("", a.deletePolicy)
+		policyRoute.GET("", a.listPolicies)
 	}
 }

--- a/api/server/router/auth/auth_routes.go
+++ b/api/server/router/auth/auth_routes.go
@@ -23,6 +23,28 @@ import (
 	"github.com/caoyingjunz/pixiu/pkg/types"
 )
 
+type IdMeta struct {
+	PolicyId int64 `uri:"policyId" binding:"required"`
+}
+
+func (a *authRouter) listPolicies(c *gin.Context) {
+	r := httputils.NewResponse()
+	var (
+		req types.ListRBACPolicyRequest
+		err error
+	)
+	if err = c.ShouldBindQuery(&req); err != nil {
+		httputils.SetFailed(c, r, err)
+		return
+	}
+	if r.Result, err = a.c.Auth().ListRBACPolicies(c, &req); err != nil {
+		httputils.SetFailed(c, r, err)
+		return
+	}
+
+	httputils.SetSuccess(c, r)
+}
+
 func (a *authRouter) createPolicy(c *gin.Context) {
 	r := httputils.NewResponse()
 	var req types.RBACPolicyRequest

--- a/pkg/types/request.go
+++ b/pkg/types/request.go
@@ -142,6 +142,13 @@ type (
 		Operation  model.Operation  `json:"operation" binding:"required,rbac_operation"`
 	}
 
+	ListRBACPolicyRequest struct {
+		UserId     int64             `form:"user_id" binding:"required"`
+		ObjectType *model.ObjectType `form:"object_type" binding:"omitempty,required_with=UserId,rbac_object"`
+		SID        *string           `form:"sid" binding:"omitempty,required_with=ObjectType,rbac_sid"`
+		Operation  *model.Operation  `form:"operation" binding:"omitempty,required_with=SID,rbac_operation"`
+	}
+
 	// PageRequest 分配配置
 	PageRequest struct {
 		Page  int `form:"page" json:"page"`   // 页数，表示第几页

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -305,3 +305,10 @@ type Haproxy struct {
 	Enable                    bool   `json:"enable"`                       // Enable haproxy and keepalived,
 	KeepalivedVirtualRouterId string `json:"keepalived_virtual_router_id"` // Arbitrary unique number from 0..255
 }
+
+type RBACPolicy struct {
+	Username   string           `json:"username"`
+	ObjectType model.ObjectType `json:"resource_type"`
+	StringID   string           `json:"sid"`
+	Operation  model.Operation  `json:"operation"`
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add a RBAC policies listing API.

#### Does this PR introduce a user-facing change?

Running `curl` like this:

```bash
$ curl -s -H 'Authorization: Bearer '${token}'' -X GET http://127.0.0.1:8090/pixiu/auth/policy\?user_id\=3 | jq
{
  "code": 200,
  "result": [
    {
      "username": "HF1",
      "resource_type": "clusters",
      "sid": "11",
      "operation": "*"
    }
  ],
  "message": "success"
}

$ curl -s -H 'Authorization: Bearer '${token}'' -X GET http://127.0.0.1:8090/pixiu/auth/policy\?user_id\=3\&object_type\=clusters | jq
{
  "code": 200,
  "result": [
    {
      "username": "HF1",
      "resource_type": "clusters",
      "sid": "11",
      "operation": "*"
    }
  ],
  "message": "success"
}
```