### PR TITLE
Add a group binding delete API

### DIFF
--- a/api/server/router/auth/auth.go
+++ b/api/server/router/auth/auth.go
@@ -51,5 +51,6 @@ func (a *authRouter) initRoutes(ge *gin.Engine) {
 	{
 		bindingRoute := authRoute.Group(BindingSubPath)
 		bindingRoute.POST("", a.createBinding)
+		bindingRoute.DELETE("", a.deleteBinding)
 	}
 }

--- a/api/server/router/auth/auth_routes.go
+++ b/api/server/router/auth/auth_routes.go
@@ -89,3 +89,18 @@ func (a *authRouter) createBinding(c *gin.Context) {
 
 	httputils.SetSuccess(c, r)
 }
+
+func (a *authRouter) deleteBinding(c *gin.Context) {
+	r := httputils.NewResponse()
+	var req types.GroupBindingRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputils.SetFailed(c, r, err)
+		return
+	}
+	if err := a.c.Auth().DeleteGroupBinding(c, &req); err != nil {
+		httputils.SetFailed(c, r, err)
+		return
+	}
+
+	httputils.SetSuccess(c, r)
+}

--- a/pkg/controller/auth/auth.go
+++ b/pkg/controller/auth/auth.go
@@ -42,6 +42,7 @@ type (
 		ListRBACPolicies(ctx context.Context, req *types.ListRBACPolicyRequest) ([]types.RBACPolicy, error)
 
 		CreateGroupBinding(ctx context.Context, req *types.GroupBindingRequest) error
+		DeleteGroupBinding(ctx context.Context, req *types.GroupBindingRequest) error
 	}
 )
 
@@ -197,6 +198,24 @@ func (a *auth) CreateGroupBinding(ctx context.Context, req *types.GroupBindingRe
 	}
 	if !ok {
 		return errors.ErrGroupBindingExists
+	}
+
+	return nil
+}
+
+func (a *auth) DeleteGroupBinding(ctx context.Context, req *types.GroupBindingRequest) error {
+	binding, err := a.getBinding(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	ok, err := a.enforcer.RemoveGroupingPolicy(binding.Raw())
+	if err != nil {
+		klog.Errorf("failed to delete binding %v: %v", binding, err)
+		return errors.ErrServerInternal
+	}
+	if !ok {
+		return errors.ErrGroupBindingNotFound
 	}
 
 	return nil

--- a/pkg/controller/util/util.go
+++ b/pkg/controller/util/util.go
@@ -143,7 +143,7 @@ func GetUserPolicies(enforcer *casbin.SyncedEnforcer, user *model.User, conds ..
 	}
 	policies := make([]model.UserPolicy, len(rp))
 	for i, p := range rp {
-		copy(policies[i][:], p)
+		_ = copy(policies[i][:], p)
 	}
 	return policies, nil
 }
@@ -157,6 +157,6 @@ func GetGroupPolicy(enforcer *casbin.SyncedEnforcer, name string) (*model.GroupP
 		return nil, nil
 	}
 	policy := model.GroupPolicy{}
-	copy(policy[:], rp[0])
+	_ = copy(policy[:], rp[0])
 	return &policy, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add a group binding delete API.

HTTP route: `/pixiu/auth/binding`
HTTP method: `DELETE`

#### Does this PR introduce a user-facing change?

Calling this API like `curl` command here:

```bash
curl -H 'Authorization: Bearer '${token}'' -X DELETE http://127.0.0.1:8090/pixiu/auth/binding \
  -d '{"user_id": 4, "group_name": "root"}'
```
