### PR TITLE
fix(bootstrap): 启动初始化 Runner 时绕过 Controller 权限校验

### DIFF
--- a/cmd/app/options/bootstrap.go
+++ b/cmd/app/options/bootstrap.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	pixiuModel "github.com/caoyingjunz/pixiu/pkg/db/model"
-	"github.com/caoyingjunz/pixiu/pkg/types"
 	pixiuutil "github.com/caoyingjunz/pixiu/pkg/util"
 	"k8s.io/klog/v2"
 )
@@ -288,7 +287,8 @@ func (o *Options) bootstrapRunners(ctx context.Context) error {
 			continue
 		}
 
-		if err = o.Controller.Runner().Create(ctx, &types.CreateRunnerRequest{
+		// 直接经 factory 入库，不经过 Controller.Runner().Create（其 CheckRoot 依赖请求上下文，启动阶段无 user 会报错）
+		if _, err = o.Factory.Runner().Create(ctx, &pixiuModel.Runner{
 			Name:        dr.name,
 			EngineImage: dr.engineImage,
 			Status:      pixiuModel.RunnerStatusUnstart,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Pixiu 首次启动时，`bootstrapRunners` 调用 `Controller.Runner().Create()`，其内部 `CheckRoot` 依赖 HTTP 请求上下文中的登录用户。启动阶段使用 `context.Background()`，无用户信息，导致 `get nil user` 并 fatal 退出。

本 PR 与 `bootstrapRootUser` 保持一致，改为直接调用 `Factory.Runner().Create()`，绕过 Controller 层权限校验。

#### Which issue(s) this PR fixes:
Fixes #957

#### Special notes for your reviewer:
已在 Ubuntu 22.04 + MySQL 环境验证：全新数据库启动后日志出现 `runner initialization completed`，服务正常监听，无 `get nil user`。

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```