### PR TITLE
feat(cluster): 新增 Service 关联 Pod 查询 API

### DIFF
--- a/api/server/router/cluster/cluster.go
+++ b/api/server/router/cluster/cluster.go
@@ -87,6 +87,7 @@ func (cr *clusterRouter) initRoutes(ginEngine *gin.Engine) {
 			{Method: "GET", RelativePath: "/clusters/:cluster/namespaces/:namespace/pods/:pod/log", Handler: cr.watchPodLog, Description: "Pod日志"},
 			{Method: "GET", RelativePath: "/clusters/:cluster/namespaces/:namespace/name/:name/kind/:kind/events", Handler: cr.aggregateEvents, Description: "聚合事件"},
 			//{Method: "GET", RelativePath: "/clusters/:cluster/api/v1/events", Handler: cr.getEventList, Description: "事件列表"},
+			{Method: "GET", RelativePath: "/clusters/:cluster/namespaces/:namespace/services/:name/pods", Handler: cr.listServicePods, Description: "Service关联Pod"},
 			{Method: "POST", RelativePath: "/clusters/:cluster/namespaces/:namespace/jobs/:name", Handler: cr.ReRunJob, Description: "重新执行Job"},
 			// ws 相关入口
 			{Method: "GET", RelativePath: "/pods/ws", Handler: cr.podWebShell, Description: "Pod WebShell"},

--- a/api/server/router/cluster/service_pods.go
+++ b/api/server/router/cluster/service_pods.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 The Pixiu Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/caoyingjunz/pixiu/api/server/errors"
+	"github.com/caoyingjunz/pixiu/api/server/httputils"
+	"github.com/caoyingjunz/pixiu/pkg/types"
+)
+
+func (cr *clusterRouter) listServicePods(c *gin.Context) {
+	r := httputils.NewResponse()
+	var (
+		optMeta types.PixiuObjectMeta
+		err     error
+	)
+	if err = c.ShouldBindUri(&optMeta); err != nil {
+		httputils.SetFailed(c, r, err)
+		return
+	}
+	if optMeta.Name == "" {
+		httputils.SetFailed(c, r, errors.NewError(fmt.Errorf("name is required"), http.StatusBadRequest))
+		return
+	}
+	if err = cr.authorizeClusterAccessByName(c, optMeta.Cluster); err != nil {
+		httputils.SetFailed(c, r, err)
+		return
+	}
+
+	includeNotReady, _ := strconv.ParseBool(c.Query("includeNotReady"))
+	if r.Result, err = cr.c.Cluster().ListServicePods(c, optMeta.Cluster, optMeta.Namespace, optMeta.Name, includeNotReady); err != nil {
+		httputils.SetFailed(c, r, err)
+		return
+	}
+	httputils.SetSuccess(c, r)
+}

--- a/pkg/controller/cluster/cluster.go
+++ b/pkg/controller/cluster/cluster.go
@@ -84,6 +84,9 @@ type Interface interface {
 	// AggregateEvents 聚合指定资源的 events
 	AggregateEvents(ctx context.Context, cluster string, namespace string, name string, kind string) (*v1.EventList, error)
 
+	// ListServicePods 列出 Service 关联的 Pod（Endpoints TargetRef，必要时回退 selector）
+	ListServicePods(ctx context.Context, cluster, namespace, name string, includeNotReady bool) (*v1.PodList, error)
+
 	// WsPodHandler pod 的 webShell
 	WsPodHandler(ctx context.Context, webShellOptions *types.WebShellOptions, w http.ResponseWriter, r *http.Request) error
 	// WsNodeHandler node 的 webShell

--- a/pkg/controller/cluster/service_pods.go
+++ b/pkg/controller/cluster/service_pods.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Pixiu Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+	"sort"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+// ListServicePods 返回 Service 关联的 Pod 列表。
+// 优先从 Endpoints TargetRef 解析（与 upstream_auth_proxy 一致）；
+// Endpoints 不存在或为空时，回退到 Service.spec.selector 列表。
+// includeNotReady=true 时同时纳入 NotReadyAddresses。
+func (c *cluster) ListServicePods(ctx context.Context, cluster, namespace, name string, includeNotReady bool) (*v1.PodList, error) {
+	clusterSet, err := c.GetClusterSetByName(ctx, cluster)
+	if err != nil {
+		return nil, err
+	}
+	client := clusterSet.Client
+
+	svc, err := client.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("failed to get service (%s/%s) in cluster %s: %v", namespace, name, cluster, err)
+		return nil, err
+	}
+
+	podNames := collectEndpointPodNames(ctx, client, namespace, name, includeNotReady)
+	if len(podNames) == 0 && len(svc.Spec.Selector) > 0 {
+		selector := labels.Set(svc.Spec.Selector).AsSelector().String()
+		listed, listErr := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: selector,
+			Limit:         500,
+		})
+		if listErr != nil {
+			klog.Errorf("failed to list pods by service selector (%s/%s): %v", namespace, name, listErr)
+			return nil, listErr
+		}
+		return listed, nil
+	}
+
+	pods := make([]v1.Pod, 0, len(podNames))
+	for _, podName := range podNames {
+		pod, getErr := client.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if getErr != nil {
+			if apierrors.IsNotFound(getErr) {
+				klog.V(2).Infof("pod %s/%s referenced by service %s endpoints not found, skipping", namespace, podName, name)
+				continue
+			}
+			klog.Errorf("failed to get pod %s/%s for service %s: %v", namespace, podName, name, getErr)
+			return nil, getErr
+		}
+		pods = append(pods, *pod)
+	}
+
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+
+	return &v1.PodList{
+		TypeMeta: metav1.TypeMeta{Kind: "PodList", APIVersion: "v1"},
+		Items:    pods,
+	}, nil
+}
+
+func collectEndpointPodNames(ctx context.Context, client kubernetes.Interface, namespace, name string, includeNotReady bool) []string {
+	eps, err := client.CoreV1().Endpoints(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		klog.Warningf("failed to get endpoints %s/%s: %v", namespace, name, err)
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	var names []string
+	add := func(addrs []v1.EndpointAddress) {
+		for _, addr := range addrs {
+			if addr.TargetRef == nil || addr.TargetRef.Kind != "Pod" || addr.TargetRef.Name == "" {
+				continue
+			}
+			podName := addr.TargetRef.Name
+			if _, ok := seen[podName]; ok {
+				continue
+			}
+			seen[podName] = struct{}{}
+			names = append(names, podName)
+		}
+	}
+
+	for _, subset := range eps.Subsets {
+		add(subset.Addresses)
+		if includeNotReady {
+			add(subset.NotReadyAddresses)
+		}
+	}
+	return names
+}


### PR DESCRIPTION
/kind feature
/kind api-change

#### What this PR does / why we need it:

对应 Issue [#948](https://github.com/caoyingjunz/pixiu/issues/948)：当前无法从 Service 查看其关联的 Pod。

本 PR 在后端新增查询接口，供前端 Service 详情页展示关联 Pod：

```text
GET /pixiu/kubeproxy/clusters/:cluster/namespaces/:namespace/services/:name/pods?includeNotReady=
```

实现说明：
1. **优先**通过 Endpoints / EndpointSlices 的 `TargetRef` 解析关联 Pod（与 kube-proxy 实际转发一致）
2. 若暂无可用 Endpoints，**回退**按 Service `spec.selector` 列出 Pod
3. 支持 `includeNotReady`，便于排查未就绪实例

配套前端改动在独立仓库 [pixiu-io/pixiu-ui](https://github.com/pixiu-io/pixiu-ui)（另开 PR），包含：
- Service 列表增加「详情」入口
- Service 详情页（基本信息 / 关联 Pod）
- 点击 Pod 名称跳转 Pod 详情

#### Which issue(s) this PR fixes:

Fixes #948

#### Special notes for your reviewer:

**改动文件**
- `pkg/controller/cluster/service_pods.go`：关联 Pod 查询逻辑
- `api/server/router/cluster/service_pods.go`：HTTP handler
- `pkg/controller/cluster/cluster.go` / `api/server/router/cluster/cluster.go`：接口与路由注册

**验证环境**
- 远程主机部署 Pixiu + k3s，集群别名 `k3s-948`
- 覆盖用例：
  - `nginx-948`（ClusterIP，2 Pod）
  - `web-a`（ClusterIP，2 Pod）
  - `web-b`（NodePort，1 Pod）
  - `web-c`（Headless，3 Pod）
  - `orphan-svc`（无匹配 selector，0 Pod）

**API 冒烟**（均返回 `code=200`，数量符合预期）

**界面验证截图**（前端联调结果，依赖本 API）

修复前：Service 列表仅有 YAML/删除，无详情入口：

（下方附图 1）

修复后：列表出现「详情」，可进入关联 Pod：

（下方附图 2–5）

#### Does this PR introduce a user-facing change?

```release-note
新增通过 Service 查询关联 Pod 的 API：GET .../services/:name/pods
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
<img width="929" height="869" alt="948-no-detail-entry" src="https://github.com/user-attachments/assets/a14a4f35-cdd2-48cf-838b-97352ed37647" />
<img width="958" height="896" alt="948-list-with-detail" src="https://github.com/user-attachments/assets/bde359c0-9f2f-45ec-87f8-686a7ffb174a" />
<img width="958" height="896" alt="verify-web-a-pods" src="https://github.com/user-attachments/assets/b0fb28ea-790b-4abe-bd94-4dcdf500bfa9" />
<img width="958" height="896" alt="verify-web-c-pods" src="https://github.com/user-attachments/assets/f6b63159-8da8-47ba-88a6-fc468f635a00" />
<img width="958" height="896" alt="verify-orphan-svc-empty" src="https://github.com/user-attachments/assets/ee123c63-6635-444f-ae75-de27c16655d9" />
<img width="958" height="896" alt="verify-pod-click-fixed" src="https://github.com/user-attachments/assets/48b7dbf6-fe28-4113-9291-86db7ea54b8a" />
