### PR TITLE
fix(proxy): 内部 service proxy 支持上游认证头（修复监控检查 no header）

### DIFF
--- a/api/server/router/proxy/proxy.go
+++ b/api/server/router/proxy/proxy.go
@@ -87,18 +87,18 @@ func (p *proxyRouter) proxyHandler(c *gin.Context) {
 		return
 	}
 
-	// 根据 X-Pixiu-Datasource-Id 从数据源配置解析上游服务（如 ES、Loki）认证信息
-	pixiuDatasourceId := strings.TrimSpace(c.Request.Header.Get(upstreamDatasourceIDHeader))
-	if len(pixiuDatasourceId) != 0 {
-		klog.Infof("proxying with datasource %s", pixiuDatasourceId)
-		if upstreamAuth := p.resolveUpstreamAuth(c, pixiuDatasourceId); upstreamAuth != "" {
-			handled, proxyErr := p.tryProxyAuthenticatedService(c, clusterSet.Client, clusterSet.Config, credName, upstreamAuth)
-			if handled {
-				if proxyErr != nil {
-					httputils.SetFailed(c, resp, proxyErr)
-				}
-				return
+	// 上游 service proxy 需 Basic 认证时（数据源 ID 或 X-Pixiu-Proxy-Authorization），
+	// 绕过 apiserver proxy 经 Pod port-forward 注入 Authorization。
+	if upstreamAuth := p.resolveServiceProxyUpstreamAuth(c); upstreamAuth != "" {
+		if dsID := strings.TrimSpace(c.Request.Header.Get(upstreamDatasourceIDHeader)); dsID != "" {
+			klog.Infof("proxying with datasource %s", dsID)
+		}
+		handled, proxyErr := p.tryProxyAuthenticatedService(c, clusterSet.Client, clusterSet.Config, credName, upstreamAuth)
+		if handled {
+			if proxyErr != nil {
+				httputils.SetFailed(c, resp, proxyErr)
 			}
+			return
 		}
 	}
 

--- a/api/server/router/proxy/upstream_auth_resolve.go
+++ b/api/server/router/proxy/upstream_auth_resolve.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -27,6 +28,18 @@ import (
 )
 
 const upstreamDatasourceIDHeader = "X-Pixiu-Datasource-Id"
+
+// resolveServiceProxyUpstreamAuth 解析集群内 service proxy 的上游 Basic 认证。
+// K8s apiserver 的 service proxy 会剥离 Authorization，需经 port-forward 注入认证。
+// 优先 X-Pixiu-Datasource-Id（已保存数据源），否则读取 X-Pixiu-Proxy-Authorization（创建/测试前临时认证）。
+func (p *proxyRouter) resolveServiceProxyUpstreamAuth(c *gin.Context) string {
+	if dsID := strings.TrimSpace(c.Request.Header.Get(upstreamDatasourceIDHeader)); dsID != "" {
+		if auth := p.resolveUpstreamAuth(c, dsID); auth != "" {
+			return auth
+		}
+	}
+	return strings.TrimSpace(c.Request.Header.Get(externalProxyAuthorizationHeaderKey))
+}
 
 func (p *proxyRouter) resolveUpstreamAuth(c *gin.Context, dsIDStr string) string {
 	if dsIDStr == "" {

--- a/api/server/router/proxy/upstream_auth_resolve.go
+++ b/api/server/router/proxy/upstream_auth_resolve.go
@@ -17,7 +17,6 @@ limitations under the License.
 package proxy
 
 import (
-	"context"
 	"encoding/base64"
 	"strconv"
 	"strings"
@@ -51,7 +50,7 @@ func (p *proxyRouter) resolveUpstreamAuth(c *gin.Context, dsIDStr string) string
 	if err != nil || datasourceID <= 0 {
 		return ""
 	}
-	datasource, err := p.c.Datasource().Get(context.TODO(), datasourceID)
+	datasource, err := p.c.Datasource().Get(c, datasourceID)
 	if err != nil || datasource == nil {
 		return ""
 	}
@@ -72,6 +71,10 @@ func (p *proxyRouter) resolveUpstreamAuth(c *gin.Context, dsIDStr string) string
 		username = datasource.Config.Alert.UserName
 		password = datasource.Config.Alert.Password
 	default:
+		return ""
+	}
+
+	if strings.TrimSpace(username) == "" && strings.TrimSpace(password) == "" {
 		return ""
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

修复 [#956](https://github.com/caoyingjunz/pixiu/issues/956)：内部 Prometheus / ES / Loki 等监控数据源走 `/pixiu/proxy/.../services/.../proxy` 时，**Kubernetes apiserver 会剥离 `Authorization`**，导致上游 Basic Auth 丢失，连接测试/PromQL 表现为 `no header` / 401。

**改动要点：**

1. 集群内 service proxy 除已有 `X-Pixiu-Datasource-Id` 外，新增识别 **`X-Pixiu-Proxy-Authorization`**（创建/测试未落库数据源时的临时认证）。
2. 有上游认证信息时，绕过 apiserver service proxy，经 **Pod port-forward** 注入 `Authorization`（与历史 ES 修复同路径）。
3. `resolveUpstreamAuth` 使用请求的 `gin.Context`（不再 `context.TODO()`），避免 `Datasource.Get` 权限校验拿不到登录用户而静默失败，导致 `X-Pixiu-Datasource-Id` 不生效。
4. 用户名与密码均为空时不生成伪 Basic 头。

**配合前端 PR**（`pixiu-ui` 分支 `fix/956-datasource-proxy-auth`）：抽屉「连接测试」与内部 PromQL 查询统一携带上述认证头。

#### Which issue(s) this PR fixes:
Fixes #956

#### Special notes for your reviewer:

**验证环境**
- 集群内部署带 Basic Auth 的 Prometheus
- 数据源：内部 URL `http://prometheus-auth.monitoring.svc:9090`

**API 回归（`mode: release`）**

| 场景 | 期望 |
|------|------|
| 已登录，无上游认证头 | 401 Unauthorized |
| 已登录 + `X-Pixiu-Proxy-Authorization` | 200 Ready |
| 已登录 + `X-Pixiu-Datasource-Id` | 200 Ready |
| PromQL `up{job="node"}` | 200 + 指标 |
| 未登录 + 任意上游认证头 | 401（不可绕过 JWT） |
| 低权限用户 | 403 无权限 |
| 错误上游 Basic / 伪造 Datasource-Id / 走私头 | 无法解锁 Ready |

**UI 验证**
- 数据源编辑 → 测试 →「连接测试成功」
- 监控大盘状态「正常」；资源趋势有曲线（node-exporter + cAdvisor 用于填充分盘，与认证修复独立）

截图见下方附件。

#### Does this PR introduce a user-facing change?
```release-note
内部监控数据源连接测试/查询支持经 X-Pixiu-Proxy-Authorization 与 X-Pixiu-Datasource-Id 注入上游认证，修复 apiserver 剥离 Authorization 导致的 no header/401。
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```

### Screenshots
<img width="1187" height="896" alt="verify-956-connection-ok" src="https://github.com/user-attachments/assets/2145a7b8-8816-41d2-a49e-9bb00618a3b6" />
<img width="1187" height="896" alt="rescan-956-ui-connection-ok" src="https://github.com/user-attachments/assets/e7460a48-aa1c-4cf3-9191-cc687bd954c1" />
<img width="1187" height="896" alt="verify-956-dashboard-ok" src="https://github.com/user-attachments/assets/bd262451-a526-4a85-92f5-dfb8e15e8cca" />
<img width="1187" height="896" alt="verify-956-resource-trends" src="https://github.com/user-attachments/assets/a1a04b3a-e999-45f3-995a-ff433392ffce" />
<img width="1187" height="896" alt="verify-956-node-monitor" src="https://github.com/user-attachments/assets/b506e198-8a1d-40fa-8ee0-d53b8b52a1ed" />
